### PR TITLE
Add responsive frontend templates for travel planner

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -10,13 +10,13 @@ def login(request):
         username = request.POST['username']
         password = request.POST['password']
 
-        user = auth.authenticate(username=username,password=password)
+        user = auth.authenticate(username=username, password=password)
 
-        if User is not None:
-            auth.login(request,user)
+        if user is not None:
+            auth.login(request, user)
             return redirect('/')
         else:
-            messages.info(request,'Invalid Credentials')
+            messages.info(request, 'Invalid Credentials')
             return redirect('login')
     else:
         return  render(request, 'login.html')
@@ -53,5 +53,6 @@ def register(request):
         return render(request, 'register.html')
 
 def logout(request):
-    auth.logout()
+    auth.logout(request)
     return redirect('/')
+

--- a/backend/travello/urls.py
+++ b/backend/travello/urls.py
@@ -4,5 +4,7 @@ from . import views
 urlpatterns = [
     path('', views.index, name='index'),
     path('destination/<int:dest_id>/', views.destination, name='destination'),
+    path('trip/<int:trip_id>/', views.trip_detail, name='trip_detail'),
+    path('activity/<int:activity_id>/', views.activity_detail, name='activity_detail'),
 
 ]

--- a/backend/travello/views.py
+++ b/backend/travello/views.py
@@ -1,13 +1,30 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, get_object_or_404
 
-from .models import Destination
+from .models import Destination, Trip, Activity
+
 
 def index(request):
-    dests = Destination.objects.all()
-    return render(request,'index.html',{'dest':dests})
+    destinations = Destination.objects.all()
+    return render(request, "index.html", {"destinations": destinations})
 
-@login_required(login_url='login')
-def destination(request,dest_id):
-    dest = get_object_or_404(Destination,pk=dest_id)
-    return render(request,'destination.html',{'dest':dest})
+
+@login_required(login_url="login")
+def destination(request, dest_id):
+    dest = get_object_or_404(Destination, pk=dest_id)
+    trips = dest.trips.all()
+    activities = dest.activities.all()
+    context = {"dest": dest, "trips": trips, "activities": activities}
+    return render(request, "destination.html", context)
+
+
+@login_required(login_url="login")
+def trip_detail(request, trip_id):
+    trip = get_object_or_404(Trip, pk=trip_id)
+    return render(request, "trip_detail.html", {"trip": trip})
+
+
+@login_required(login_url="login")
+def activity_detail(request, activity_id):
+    activity = get_object_or_404(Activity, pk=activity_id)
+    return render(request, "activity_detail.html", {"activity": activity})

--- a/frontend/templates/activity_detail.html
+++ b/frontend/templates/activity_detail.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block title %}{{ activity.name }}{% endblock %}
+{% block content %}
+<h1>{{ activity.name }}</h1>
+<img src="{{ activity.img.url }}" class="img-fluid mb-3" alt="{{ activity.name }}">
+<p>{{ activity.desc }}</p>
+<p><a href="{% url 'destination' activity.destination.id %}">Back to {{ activity.destination.name }}</a></p>
+{% endblock %}

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Travel Planner{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+  <div class="container">
+    <a class="navbar-brand" href="{% url 'index' %}">Travel Planner</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav ms-auto">
+        {% if user.is_authenticated %}
+        <li class="nav-item"><a class="nav-link" href="{% url 'logout' %}">Logout</a></li>
+        {% else %}
+        <li class="nav-item"><a class="nav-link" href="{% url 'login' %}">Login</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'register' %}">Register</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">
+    {% if messages %}
+      {% for message in messages %}
+        <div class="alert alert-info">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+    {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/frontend/templates/destination.html
+++ b/frontend/templates/destination.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+{% block title %}{{ dest.name }}{% endblock %}
+{% block content %}
+<div class="mb-4">
+  <h1>{{ dest.name }}</h1>
+  <img src="{{ dest.img.url }}" class="img-fluid mb-3" alt="{{ dest.name }}">
+  <p>{{ dest.desc }}</p>
+  <p><strong>Country:</strong> {{ dest.country }} | <strong>Price:</strong> ${{ dest.price }}</p>
+</div>
+
+<h2 class="mt-5">Trips</h2>
+<div class="row mb-4">
+  {% for trip in trips %}
+  <div class="col-md-6 mb-3">
+    <div class="card h-100">
+      <div class="card-body d-flex flex-column">
+        <h5 class="card-title">{{ trip.title }}</h5>
+        <p class="card-text">{{ trip.start_date }} – {{ trip.end_date }}</p>
+        <a href="{% url 'trip_detail' trip.id %}" class="btn btn-outline-primary mt-auto">Details</a>
+      </div>
+    </div>
+  </div>
+  {% empty %}
+  <p>No trips available.</p>
+  {% endfor %}
+</div>
+
+<h2>Activities</h2>
+<div class="row">
+  {% for activity in activities %}
+  <div class="col-md-4 mb-3">
+    <div class="card h-100">
+      <img src="{{ activity.img.url }}" class="card-img-top" alt="{{ activity.name }}">
+      <div class="card-body d-flex flex-column">
+        <h5 class="card-title">{{ activity.name }}</h5>
+        <a href="{% url 'activity_detail' activity.id %}" class="btn btn-outline-secondary mt-auto">More</a>
+      </div>
+    </div>
+  </div>
+  {% empty %}
+  <p>No activities available.</p>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block title %}Destinations{% endblock %}
+{% block content %}
+<h1 class="mb-4">Discover Destinations</h1>
+<div class="row">
+  {% for dest in destinations %}
+  <div class="col-md-4 mb-4">
+    <div class="card h-100">
+      <img src="{{ dest.img.url }}" class="card-img-top" alt="{{ dest.name }}">
+      <div class="card-body d-flex flex-column">
+        <h5 class="card-title">{{ dest.name }}</h5>
+        <p class="card-text">{{ dest.country }} - ${{ dest.price }}</p>
+        <a href="{% url 'destination' dest.id %}" class="btn btn-primary mt-auto">View</a>
+      </div>
+    </div>
+  </div>
+  {% empty %}
+  <p>No destinations available.</p>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/frontend/templates/login.html
+++ b/frontend/templates/login.html
@@ -1,23 +1,17 @@
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Login</title>
-</head>
-<body>
-<form action="login" method="post">
-    {% csrf_token %}
-    <input type="text" name="username" placeholder="username"><br>
-    <input type="password" name="password" placeholder="password"><br>
-    <input type="submit">
-
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1 class="mb-4">Login</h1>
+<form method="post">
+  {% csrf_token %}
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
 </form>
-
-<div>
-    {% for message in messages %}
-    <h3>  {{message}} </h3>
-    {% endfor %}
-</div>
-
-</body>
-</html>
+{% endblock %}

--- a/frontend/templates/register.html
+++ b/frontend/templates/register.html
@@ -1,26 +1,37 @@
-<!DOCTYPE html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Registration</title>
-</head>
-<body>
-<form action="register" method="post">
-    {% csrf_token %}
-    <input type="text" name="first_name" placeholder="First Name" required><br>
-    <input type="text" name="last_name" placeholder="Last Name" required><br>
-    <input type="text" name="username" placeholder="Username" required><br>
-    <input type="email" name="email" placeholder="Email" required><br>
-    <input type="password" name="password1" placeholder="Password" required><br>
-    <input type="password" name="password2" placeholder="Confirm Password" required><br>
-    <input type="submit" value="Register">
-
-    <div>
-        {% for message in messages %}
-            <h3>{{ message }}</h3>
-        {% endfor %}
+{% extends 'base.html' %}
+{% block title %}Register{% endblock %}
+{% block content %}
+<h1 class="mb-4">Register</h1>
+<form method="post">
+  {% csrf_token %}
+  <div class="row">
+    <div class="col-md-6 mb-3">
+      <label for="first_name" class="form-label">First Name</label>
+      <input type="text" class="form-control" id="first_name" name="first_name" required>
     </div>
+    <div class="col-md-6 mb-3">
+      <label for="last_name" class="form-label">Last Name</label>
+      <input type="text" class="form-control" id="last_name" name="last_name" required>
+    </div>
+  </div>
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="email" class="form-label">Email</label>
+    <input type="email" class="form-control" id="email" name="email" required>
+  </div>
+  <div class="row">
+    <div class="col-md-6 mb-3">
+      <label for="password1" class="form-label">Password</label>
+      <input type="password" class="form-control" id="password1" name="password1" required>
+    </div>
+    <div class="col-md-6 mb-3">
+      <label for="password2" class="form-label">Confirm Password</label>
+      <input type="password" class="form-control" id="password2" name="password2" required>
+    </div>
+  </div>
+  <button type="submit" class="btn btn-success">Register</button>
 </form>
-
-</body>
-</Doctypehtml>
+{% endblock %}

--- a/frontend/templates/trip_detail.html
+++ b/frontend/templates/trip_detail.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block title %}{{ trip.title }}{% endblock %}
+{% block content %}
+<h1>{{ trip.title }}</h1>
+<p class="text-muted">{{ trip.start_date }} – {{ trip.end_date }}</p>
+<p>{{ trip.desc }}</p>
+<p><a href="{% url 'destination' trip.destination.id %}">Back to {{ trip.destination.name }}</a></p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Implement Bootstrap-based base layout and page templates for destinations, details, authentication, trips, and activities
- Extend views and URLs to serve new templates and show related trips and activities
- Fix login/logout views for proper authentication handling

## Testing
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6897b0dfabec8331918b77b31121669b