### PR TITLE
Add map routing and API

### DIFF
--- a/backend/travello/urls.py
+++ b/backend/travello/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path('destination/<int:dest_id>/', views.destination, name='destination'),
     path('trip/<int:trip_id>/', views.trip_detail, name='trip_detail'),
     path('activity/<int:activity_id>/', views.activity_detail, name='activity_detail'),
+    path('api/route/', views.route, name='api_route'),
 
 ]

--- a/backend/travello/views.py
+++ b/backend/travello/views.py
@@ -1,5 +1,9 @@
 from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse
 from django.shortcuts import render, get_object_or_404
+from django.views.decorators.http import require_GET
+import json
+import requests
 
 from .models import Destination, Trip, Activity
 
@@ -21,10 +25,42 @@ def destination(request, dest_id):
 @login_required(login_url="login")
 def trip_detail(request, trip_id):
     trip = get_object_or_404(Trip, pk=trip_id)
-    return render(request, "trip_detail.html", {"trip": trip})
+    activities = trip.destination.activities.all()
+    route_data = {
+        "start": {"lat": trip.destination.latitude, "lng": trip.destination.longitude},
+        "end": {"lat": trip.destination.latitude, "lng": trip.destination.longitude},
+        "waypoints": [
+            {"lat": act.latitude, "lng": act.longitude, "name": act.name}
+            for act in activities
+        ],
+    }
+    context = {"trip": trip, "route_data": json.dumps(route_data)}
+    return render(request, "trip_detail.html", context)
 
 
 @login_required(login_url="login")
 def activity_detail(request, activity_id):
     activity = get_object_or_404(Activity, pk=activity_id)
     return render(request, "activity_detail.html", {"activity": activity})
+
+
+@require_GET
+def route(request):
+    start = request.GET.get("start")
+    end = request.GET.get("end")
+    waypoints = request.GET.get("waypoints")
+    if not start or not end:
+        return JsonResponse({"error": "start and end required"}, status=400)
+    coords = start
+    if waypoints:
+        coords += ";" + waypoints
+    coords += ";" + end
+    url = (
+        f"https://router.project-osrm.org/route/v1/driving/{coords}?overview=full&geometries=geojson"
+    )
+    try:
+        res = requests.get(url, timeout=10)
+        res.raise_for_status()
+    except requests.RequestException:
+        return JsonResponse({"error": "routing failed"}, status=502)
+    return JsonResponse(res.json())

--- a/frontend/static/js/map.js
+++ b/frontend/static/js/map.js
@@ -1,11 +1,41 @@
-var map = L.map('map').setView([51.505, -0.09], 13);
+document.addEventListener('DOMContentLoaded', function () {
+    const dataEl = document.getElementById('route-data');
+    if (!dataEl) {
+        return;
+    }
+    const data = JSON.parse(dataEl.textContent);
 
-L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
-    attribution: '© OpenStreetMap contributors © Mapbox',
-    maxZoom: 18,
-    id: 'mapbox/streets-v11',
-    tileSize: 512,
-    zoomOffset: -1,
-    accessToken: 'your.mapbox.access.token'
-}).addTo(map);
+    const map = L.map('map').setView([data.start.lat, data.start.lng], 13);
 
+    L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+        attribution: '© OpenStreetMap contributors © Mapbox',
+        maxZoom: 18,
+        id: 'mapbox/streets-v11',
+        tileSize: 512,
+        zoomOffset: -1,
+        accessToken: 'your.mapbox.access.token'
+    }).addTo(map);
+
+    const points = [[data.start.lat, data.start.lng]];
+    L.marker([data.start.lat, data.start.lng]).addTo(map).bindPopup('Start');
+
+    data.waypoints.forEach(function (wp) {
+        L.marker([wp.lat, wp.lng]).addTo(map).bindPopup(wp.name || 'Activity');
+        points.push([wp.lat, wp.lng]);
+    });
+
+    L.marker([data.end.lat, data.end.lng]).addTo(map).bindPopup('End');
+    points.push([data.end.lat, data.end.lng]);
+
+    L.polyline(points, { color: 'blue' }).addTo(map);
+    map.fitBounds(points);
+
+    document.getElementById('start-point').textContent = data.start.lat + ', ' + data.start.lng;
+    document.getElementById('end-point').textContent = data.end.lat + ', ' + data.end.lng;
+    const wpList = document.getElementById('waypoints');
+    data.waypoints.forEach(function (wp) {
+        const li = document.createElement('li');
+        li.textContent = (wp.name || '') + ' (' + wp.lat + ', ' + wp.lng + ')';
+        wpList.appendChild(li);
+    });
+});

--- a/frontend/templates/trip_detail.html
+++ b/frontend/templates/trip_detail.html
@@ -5,7 +5,15 @@
 <h1>{{ trip.title }}</h1>
 <p class="text-muted">{{ trip.start_date }} – {{ trip.end_date }}</p>
 <p>{{ trip.desc }}</p>
-<div id="map" style="height: 400px;"></div>
+<div id="map-container">
+    <div id="map" style="height: 400px;"></div>
+    <div id="route-info">
+        <p>Start: <span id="start-point"></span></p>
+        <p>End: <span id="end-point"></span></p>
+        <ul id="waypoints"></ul>
+    </div>
+</div>
 <p><a href="{% url 'destination' trip.destination.id %}">Back to {{ trip.destination.name }}</a></p>
+<script id="route-data" type="application/json">{{ route_data|safe }}</script>
 <script src="{% static 'js/map.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show map with route and activity markers
- serve coordinates and optional route calculation via backend

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6897e6792a848331bca6c4cfc93db78f